### PR TITLE
Enforce OCSP request size limits for GET/POST and add IdleTimeout

### DIFF
--- a/cache_handler.go
+++ b/cache_handler.go
@@ -27,10 +27,6 @@ func handleHTTPMethod(h http.Handler) http.Handler {
 		switch r.Method {
 		case http.MethodPost:
 		case http.MethodGet:
-			if r.ContentLength > int64(GETMethodMaxRequestSize) {
-				w.WriteHeader(http.StatusMethodNotAllowed)
-				return
-			}
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -44,9 +40,15 @@ func handleOverMaxRequestBytes(max int) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if max > 0 {
-				if r.ContentLength > int64(max) {
-					w.WriteHeader(http.StatusRequestEntityTooLarge)
-					return
+				switch r.Method {
+				case http.MethodGet:
+					reqPath := strings.TrimPrefix(r.URL.Path, "/")
+					if len(reqPath) > base64.StdEncoding.EncodedLen(max) {
+						w.WriteHeader(http.StatusRequestEntityTooLarge)
+						return
+					}
+				case http.MethodPost:
+					r.Body = http.MaxBytesReader(w, r.Body, int64(max))
 				}
 			}
 			h.ServeHTTP(w, r)
@@ -199,6 +201,10 @@ func (c CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		reqPath := strings.TrimPrefix(r.URL.Path, "/")
+		if c.maxRequestBytes > 0 && len(reqPath) > base64.StdEncoding.EncodedLen(c.maxRequestBytes) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
 		logger.Debug().Err(err).Str("ocsp-request-path", reqPath).Msg("")
 		body, err = base64.StdEncoding.DecodeString(reqPath)
 	case http.MethodPost:
@@ -207,7 +213,20 @@ func (c CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err = ErrUnexpectedHTTPMethod
 	}
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
 		logger.Error().Err(err).Msg("")
+		return
+	}
+	if c.maxRequestBytes > 0 && len(body) > c.maxRequestBytes {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+	if r.Method == http.MethodGet && len(body) > GETMethodMaxRequestSize {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/cache_handler_test.go
+++ b/cache_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	stduri "net/url"
 	"reflect"
 	"regexp"
@@ -148,6 +149,48 @@ func TestCacheHandler_ServeHTTP_OverMaxRequestSize(t *testing.T) {
 
 	if res.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Errorf("Expected status code is 413 but got: %d", res.StatusCode)
+	}
+}
+
+func TestCacheHandler_ServeHTTP_OverMaxRequestSize_ChunkedPOST(t *testing.T) {
+	t.Parallel()
+
+	cacheStore := cache.NewResponseCacheStore()
+	responder := testCreateDelegatedResponder(t)
+	handler := NewCacheHandler(
+		cacheStore.NewReadOnlyCacheStore(), responder, alice.New(),
+		WithMaxRequestBytes(1), WithMaxAge(256),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte{0xFF, 0xFF, 0xFF}))
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("Expected status code is 413 but got: %d", rec.Code)
+	}
+}
+
+func TestCacheHandler_ServeHTTP_OverMaxRequestSize_GETPath(t *testing.T) {
+	t.Parallel()
+
+	cacheStore := cache.NewResponseCacheStore()
+	responder := testCreateDelegatedResponder(t)
+	handler := NewCacheHandler(
+		cacheStore.NewReadOnlyCacheStore(), responder, alice.New(),
+		WithMaxRequestBytes(10), WithMaxAge(256),
+	)
+
+	oversizedReqPath := "/" + base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0xFF}, 11))
+	req := httptest.NewRequest(http.MethodGet, oversizedReqPath, nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("Expected status code is 413 but got: %d", rec.Code)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -17,6 +17,7 @@ func CreateHTTPServer(
 		Handler:           handler,
 		ReadTimeout:       time.Duration(cfg.ReadTimeout),
 		WriteTimeout:      time.Second * time.Duration(cfg.WriteTimeout),
+		IdleTimeout:       time.Second * time.Duration(cfg.WriteTimeout),
 		ReadHeaderTimeout: time.Second * time.Duration(cfg.ReadHeaderTimeout),
 		MaxHeaderBytes:    cfg.MaxHeaderBytes,
 	}


### PR DESCRIPTION
### Motivation

- Prevent oversized OCSP requests from being processed or from bypassing limits (e.g., chunked `POST` or oversized base64 `GET` paths) which could lead to excessive memory use or DoS.
- Harden the HTTP server against slow/idle connections by adding an `IdleTimeout`.

### Description

- Enforce configured request-size limits in `CacheHandler` by wrapping `POST` bodies with `http.MaxBytesReader` and rejecting oversized decoded `GET` paths before base64 decoding in `cache_handler.go`.
- Add runtime checks after reading to return `http.StatusRequestEntityTooLarge` for requests that exceed `WithMaxRequestBytes` and enforce `GET` method decoded-body max using `GETMethodMaxRequestSize`.
- Add `IdleTimeout` based on `cfg.WriteTimeout` in `CreateHTTPServer` (`server.go`) to limit idle connections.
- Add regression tests in `cache_handler_test.go` covering oversized chunked `POST` bodies (`TestCacheHandler_ServeHTTP_OverMaxRequestSize_ChunkedPOST`) and oversized base64 `GET` paths (`TestCacheHandler_ServeHTTP_OverMaxRequestSize_GETPath`).

### Testing

- Ran formatting with `gofmt -w cache_handler.go cache_handler_test.go server.go`, which completed successfully.
- Ran the full test suite with `go test ./...` and observed all packages tested as `ok` or cached with no failures.
- Ran targeted tests `go test ./... -run 'TestCacheHandler_ServeHTTP_(OverMaxRequestSize|GET_ResponseSuccess|POST_ResponseSuccess)'` and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1454fd4ec83248cad00e2cf3d4161)