### PR TITLE
Harden PKI input validation and HTTP timeouts

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -133,6 +133,17 @@ func parsePKCS8PrivKey(block *pem.Block) (crypto.PrivateKey, error) {
 	return key, nil
 }
 
+func decodePEM(input []byte, resource pKIResource) (*pem.Block, error) {
+	block, rest := pem.Decode(input)
+	if block == nil {
+		return nil, invalidPKIResourceError{resource, "PEM block not found."}
+	}
+	if len(bytes.TrimSpace(rest)) != 0 {
+		return nil, invalidPKIResourceError{resource, "unexpected data found after PEM block."}
+	}
+	return block, nil
+}
+
 func detectPrivKeyAlgorithm(key crypto.PrivateKey) (KeyAlg, bool) {
 	_, ok := key.(*rsa.PrivateKey)
 	if ok {
@@ -183,7 +194,10 @@ func detectAuthType(cert *x509.Certificate) AuthorizedType {
 // returns a new dyocsp.Responder instance.
 func BuildResponder(rCertPem, rPrivKeyPem, issuerCertPem []byte, nowT time.Time) (*Responder, error) {
 	// Parse Responder Certificate
-	rCertblock, _ := pem.Decode(rCertPem)
+	rCertblock, err := decodePEM(rCertPem, responderCert)
+	if err != nil {
+		return nil, err
+	}
 	rCert, err := x509.ParseCertificate(rCertblock.Bytes)
 	if err != nil {
 		return nil, err
@@ -191,7 +205,10 @@ func BuildResponder(rCertPem, rPrivKeyPem, issuerCertPem []byte, nowT time.Time)
 
 	// Parse Responder Key
 	rKeyFormat := detectPrivKeyPemFormat(rPrivKeyPem)
-	keyblock, _ := pem.Decode(rPrivKeyPem)
+	keyblock, err := decodePEM(rPrivKeyPem, responderKey)
+	if err != nil {
+		return nil, err
+	}
 	var rPrivKey crypto.PrivateKey
 	switch rKeyFormat {
 	case PKCS8:
@@ -211,7 +228,10 @@ func BuildResponder(rCertPem, rPrivKeyPem, issuerCertPem []byte, nowT time.Time)
 	}
 
 	// Parse Issuer Certificate
-	iCertblock, _ := pem.Decode(issuerCertPem)
+	iCertblock, err := decodePEM(issuerCertPem, issuerCert)
+	if err != nil {
+		return nil, err
+	}
 	iCert, err := x509.ParseCertificate(iCertblock.Bytes)
 	if err != nil {
 		return nil, err

--- a/responder_test.go
+++ b/responder_test.go
@@ -18,6 +18,46 @@ func cnvSerialStr2BigInt(serialStr string) *big.Int {
 	return serial
 }
 
+func TestBuildResponderRejectsInvalidPEM(t *testing.T) {
+	t.Parallel()
+
+	readTestFile := func(name string) []byte {
+		t.Helper()
+		data, err := os.ReadFile("testdata/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+
+	validCert := readTestFile("sub-ocsp-rsa.crt")
+	validKey := readTestFile("sub-ocsp-rsa-pkcs8.key")
+	validIssuer := readTestFile("sub-ca-rsa.crt")
+
+	tests := []struct {
+		name       string
+		cert       []byte
+		key        []byte
+		issuer     []byte
+		wantErrMsg string
+	}{
+		{"missing responder certificate PEM", []byte("not PEM"), validKey, validIssuer, "invalid responder certificate: PEM block not found."},
+		{"missing private key PEM", validCert, []byte("not PEM"), validIssuer, "invalid private Key: PEM block not found."},
+		{"missing issuer certificate PEM", validCert, validKey, []byte("not PEM"), "invalid issuer certificate: PEM block not found."},
+		{"trailing responder certificate data", append(validCert, []byte("\nunexpected")...), validKey, validIssuer, "invalid responder certificate: unexpected data found after PEM block."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := BuildResponder(tt.cert, tt.key, tt.issuer, time.Now())
+			if err == nil || err.Error() != tt.wantErrMsg {
+				t.Fatalf("BuildResponder() error = %v, want %q", err, tt.wantErrMsg)
+			}
+		})
+	}
+}
+
 func TestBuildResponder(t *testing.T) {
 	t.Parallel()
 	data := []struct {

--- a/server.go
+++ b/server.go
@@ -15,7 +15,7 @@ func CreateHTTPServer(
 	return &http.Server{
 		Addr:              host,
 		Handler:           handler,
-		ReadTimeout:       time.Duration(cfg.ReadTimeout),
+		ReadTimeout:       time.Second * time.Duration(cfg.ReadTimeout),
 		WriteTimeout:      time.Second * time.Duration(cfg.WriteTimeout),
 		IdleTimeout:       time.Second * time.Duration(cfg.WriteTimeout),
 		ReadHeaderTimeout: time.Second * time.Duration(cfg.ReadHeaderTimeout),

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,30 @@
+package dyocsp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/yuxki/dyocsp/pkg/config"
+)
+
+func TestCreateHTTPServerTimeoutsUseSeconds(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DyOCSPConfig{
+		ReadTimeout:       2,
+		WriteTimeout:      3,
+		ReadHeaderTimeout: 4,
+	}
+	server := CreateHTTPServer(":8080", cfg, http.NotFoundHandler())
+
+	if server.ReadTimeout != 2*time.Second {
+		t.Errorf("ReadTimeout = %v, want %v", server.ReadTimeout, 2*time.Second)
+	}
+	if server.WriteTimeout != 3*time.Second {
+		t.Errorf("WriteTimeout = %v, want %v", server.WriteTimeout, 3*time.Second)
+	}
+	if server.ReadHeaderTimeout != 4*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", server.ReadHeaderTimeout, 4*time.Second)
+	}
+}


### PR DESCRIPTION
## Summary

- reject missing PEM blocks instead of dereferencing nil
- reject unexpected trailing data after certificate and private-key PEM blocks
- interpret the configured HTTP read timeout in seconds, consistently with the other timeout settings
- add regression tests for malformed PKI inputs and timeout units

## Why

Malformed or empty PKI configuration could panic during startup. The read timeout also converted a seconds-based integer directly to `time.Duration`, resulting in nanoseconds and making configured servers unusable.

## Impact

Invalid certificate and key configuration now fails with a descriptive error. Valid configuration behavior is unchanged, while `read_timeout` now has its documented seconds unit.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2` (`0 issues`)
