### PR TITLE
Make cache store updates race-free

### DIFF
--- a/pkg/cache/res_cache_store.go
+++ b/pkg/cache/res_cache_store.go
@@ -18,7 +18,7 @@ import (
 type ResponseCacheStore struct {
 	cacheMap  map[string]ResponseCache
 	now       date.Now
-	UpdatedAt time.Time
+	updatedAt time.Time
 	mu        sync.RWMutex
 }
 
@@ -29,7 +29,7 @@ func NewResponseCacheStore() *ResponseCacheStore {
 	return &ResponseCacheStore{
 		cacheMap:  cacheMap,
 		now:       date.NowGMT,
-		UpdatedAt: updatedAt,
+		updatedAt: updatedAt,
 	}
 }
 
@@ -45,17 +45,7 @@ func cacheMapKey(s *big.Int) (string, bool) {
 // This method returns nil when there are no duplicated serial numbers in the
 // ocsp response and returns the duplicated serial numbers when they exist.
 func (r *ResponseCacheStore) Update(caches []ResponseCache) []ResponseCache {
-	defer func() {
-		r.UpdatedAt = r.now()
-	}()
-
 	invalids := make([]ResponseCache, 0, len(caches))
-
-	if caches == nil {
-		r.cacheMap = make(map[string]ResponseCache, 0)
-		return invalids
-	}
-
 	cacheMap := make(map[string]ResponseCache, len(caches))
 	duplSet := make(map[string]struct{}, len(caches))
 
@@ -92,9 +82,18 @@ func (r *ResponseCacheStore) Update(caches []ResponseCache) []ResponseCache {
 
 	r.mu.Lock()
 	r.cacheMap = cacheMap
+	r.updatedAt = r.now()
 	r.mu.Unlock()
 
 	return invalids
+}
+
+// UpdatedAt returns the time at which the cache store was last replaced.
+func (r *ResponseCacheStore) UpdatedAt() time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.updatedAt
 }
 
 // Truncate resets/deletes all caches.
@@ -118,9 +117,8 @@ func (r *ResponseCacheStore) Get(serialNumber *big.Int) (*ResponseCache, bool) {
 	// Copy the cache map address for data protection
 	// from replacing address by the updating cache job
 	r.mu.RLock()
-	cm := r.cacheMap
+	cache, ok = r.cacheMap[key]
 	r.mu.RUnlock()
-	cache, ok = cm[key]
 	if !ok {
 		return nil, false
 	}

--- a/pkg/cache/res_cache_store_test.go
+++ b/pkg/cache/res_cache_store_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"math/big"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,9 +17,35 @@ func TestNewResponseCacheStore(t *testing.T) {
 
 	cacheStore := NewResponseCacheStore()
 	now := date.NowGMT()
-	if cacheStore.UpdatedAt.Compare(now) == 1 {
-		t.Errorf("UpdateAt is later than Now(%#v): %#v", now, cacheStore.UpdatedAt)
+	if cacheStore.UpdatedAt().Compare(now) == 1 {
+		t.Errorf("UpdateAt is later than Now(%#v): %#v", now, cacheStore.UpdatedAt())
 	}
+}
+
+func TestResponseCacheStoreConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	serial := big.NewInt(42)
+	responseCache := ResponseCache{
+		template: ocsp.Response{SerialNumber: serial},
+		response: []byte("signed response"),
+	}
+	store := NewResponseCacheStore()
+
+	var waitGroup sync.WaitGroup
+	for range 4 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			for range 100 {
+				store.Update([]ResponseCache{responseCache})
+				store.Get(serial)
+				store.UpdatedAt()
+				_ = store.Truncate()
+			}
+		}()
+	}
+	waitGroup.Wait()
 }
 
 func TestResponseCacheStore_Update_Get_Delete(t *testing.T) {
@@ -185,7 +212,7 @@ func TestResponseCacheStore_Update_Get_Delete(t *testing.T) {
 				t.Fatalf("Initial CacheStore returns false as ok but got: %#v", ok)
 			}
 
-			preAtUpdate := cacheStore.UpdatedAt
+			preAtUpdate := cacheStore.UpdatedAt()
 			cacheStore.now = func() time.Time { return time.Date(2033, 8, 9, 12, 30, 0, 0, time.UTC) }
 
 			// Update cache store
@@ -193,8 +220,8 @@ func TestResponseCacheStore_Update_Get_Delete(t *testing.T) {
 			if !reflect.DeepEqual(invalds, d.invalidCaches) {
 				t.Errorf("Expected invalid caches are %#v but: %#v", d.invalidCaches, invalds)
 			}
-			if preAtUpdate.Compare(cacheStore.UpdatedAt) == 1 {
-				t.Errorf("UpdateAt is later than previous updation(%#v): %#v", preAtUpdate, cacheStore.UpdatedAt)
+			if preAtUpdate.Compare(cacheStore.UpdatedAt()) == 1 {
+				t.Errorf("UpdateAt is later than previous updation(%#v): %#v", preAtUpdate, cacheStore.UpdatedAt())
 			}
 
 			cacheStore.now = func() time.Time { return time.Date(2033, 8, 9, 12, 30, 1, 0, time.UTC) }
@@ -211,13 +238,13 @@ func TestResponseCacheStore_Update_Get_Delete(t *testing.T) {
 				t.Errorf("Expected got cache is %#v but: %#v", d.gotCache, gotCache)
 			}
 
-			preAtUpdate = cacheStore.UpdatedAt
+			preAtUpdate = cacheStore.UpdatedAt()
 			cacheStore.now = func() time.Time { return time.Date(2033, 8, 9, 12, 30, 2, 0, time.UTC) }
 
 			// Truncate cache store
 			_ = cacheStore.Truncate()
-			if preAtUpdate.Compare(cacheStore.UpdatedAt) == 1 {
-				t.Errorf("UpdateAt is later than previous updation(%#v): %#v", preAtUpdate, cacheStore.UpdatedAt)
+			if preAtUpdate.Compare(cacheStore.UpdatedAt()) == 1 {
+				t.Errorf("UpdateAt is later than previous updation(%#v): %#v", preAtUpdate, cacheStore.UpdatedAt())
 			}
 			gotCache, ok = cacheStore.Get(serialGetNumber)
 			if ok {


### PR DESCRIPTION
## Summary

- publish cache-map replacements and their update timestamps under one lock
- make the `nil`/truncate update path use the same synchronization as normal updates
- replace the exported timestamp field with a synchronized `UpdatedAt()` accessor
- add concurrent update, lookup, timestamp, and truncate coverage

## Why

`Update(nil)` replaced the shared map without acquiring the mutex, while `UpdatedAt` was written and read outside synchronization. Concurrent truncation, cache lookup, or timestamp inspection could therefore race even though normal non-empty map replacement used a lock.

## Impact

Cache generations are now published atomically and all public reads are synchronized. Callers that read the former `UpdatedAt` field should use `UpdatedAt()` instead.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2` (`0 issues`)
