### PR TITLE
Propagate database read errors

### DIFF
--- a/pkg/db/ca_db_client.go
+++ b/pkg/db/ca_db_client.go
@@ -1,5 +1,7 @@
 package db
 
+const revTypeAttribute = "rev_type"
+
 // IntermediateEntry is a struct that holds raw data scanned from the database
 // without any modifications. This structure handles variations in data originating
 // from diverse background databases.

--- a/pkg/db/dynamodb_client.go
+++ b/pkg/db/dynamodb_client.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -78,7 +79,7 @@ func UnmarshalDynamoDBItem(item map[string]types.AttributeValue) (IntermidiateEn
 		return IntermidiateEntry{}, err
 	}
 
-	revType, err := unmarshalItem(item, "rev_type")
+	revType, err := unmarshalItem(item, revTypeAttribute)
 	if err != nil {
 		return IntermidiateEntry{}, err
 	}
@@ -106,6 +107,18 @@ func UnmarshalDynamoDBItem(item map[string]types.AttributeValue) (IntermidiateEn
 		RevDate:   revDate,
 		CRLReason: crlReason,
 	}, nil
+}
+
+func unmarshalDynamoDBItems(items []map[string]types.AttributeValue) ([]IntermidiateEntry, error) {
+	entries := make([]IntermidiateEntry, 0, len(items))
+	for idx := range items {
+		entry, err := UnmarshalDynamoDBItem(items[idx])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal DynamoDB item %d: %w", idx, err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
 }
 
 // Scan read sthe items from the table.
@@ -150,14 +163,5 @@ func (d DynamoDBClient) Scan(ctx context.Context) ([]IntermidiateEntry, error) {
 		break
 	}
 
-	entries := make([]IntermidiateEntry, 0, len(items))
-	for i := range items {
-		e, err := UnmarshalDynamoDBItem(items[i])
-		if err != nil {
-			continue
-		}
-		entries = append(entries, e)
-	}
-
-	return entries, nil
+	return unmarshalDynamoDBItems(items)
 }

--- a/pkg/db/dynamodb_client_test.go
+++ b/pkg/db/dynamodb_client_test.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func TestUnmarshalDynamoDBItemsRejectsPartialResults(t *testing.T) {
+	t.Parallel()
+
+	validItem := map[string]types.AttributeValue{
+		"ca":             &types.AttributeValueMemberS{Value: "test-ca"},
+		"serial":         &types.AttributeValueMemberS{Value: "1234"},
+		revTypeAttribute: &types.AttributeValueMemberS{Value: "V"},
+		"exp_date":       &types.AttributeValueMemberS{Value: "300101000000Z"},
+		"rev_date":       &types.AttributeValueMemberS{Value: ""},
+		"crl_reason":     &types.AttributeValueMemberS{Value: ""},
+	}
+	invalidItem := map[string]types.AttributeValue{
+		"ca": &types.AttributeValueMemberS{Value: "test-ca"},
+	}
+
+	entries, err := unmarshalDynamoDBItems([]map[string]types.AttributeValue{validItem, invalidItem})
+	if err == nil {
+		t.Fatal("unmarshalDynamoDBItems() error = nil, want malformed item error")
+	}
+	if entries != nil {
+		t.Fatalf("unmarshalDynamoDBItems() entries = %#v, want nil", entries)
+	}
+	if !strings.Contains(err.Error(), "DynamoDB item 1") {
+		t.Fatalf("unmarshalDynamoDBItems() error = %q, want item index", err)
+	}
+	if !strings.Contains(err.Error(), "serial") {
+		t.Fatalf("unmarshalDynamoDBItems() error = %q, want missing attribute", err)
+	}
+}

--- a/pkg/db/entry_exchange.go
+++ b/pkg/db/entry_exchange.go
@@ -69,13 +69,13 @@ func (e *EntryExchange) VerifyRevType(
 	if target == string(Valid) {
 		if revDate != "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but rev_date exists", Valid),
 			}
 		}
 		if crlReason != "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but crl_reason exists", Valid),
 			}
 		}
@@ -85,7 +85,7 @@ func (e *EntryExchange) VerifyRevType(
 	if target == string(Revoked) {
 		if revDate == "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but rev_date does not exist", Revoked),
 			}
 		}
@@ -93,7 +93,7 @@ func (e *EntryExchange) VerifyRevType(
 	}
 
 	return "", InvalidEntryError{
-		attr: "rev_type",
+		attr: revTypeAttribute,
 		msg:  target,
 	}
 }

--- a/pkg/db/file_db_client.go
+++ b/pkg/db/file_db_client.go
@@ -86,6 +86,9 @@ func (h FileDBClient) Scan(ctx context.Context) (entries []IntermidiateEntry, er
 		}
 		entries = append(entries, entry)
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("could not scan file DB %s: %w", h.dbFile, err)
+	}
 
 	return entries, nil
 }

--- a/pkg/db/file_db_client_test.go
+++ b/pkg/db/file_db_client_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -106,5 +108,26 @@ func TestFileDBClient_Scan(t *testing.T) {
 				t.Error(diff)
 			}
 		})
+	}
+}
+
+func TestFileDBClientScanReturnsScannerError(t *testing.T) {
+	t.Parallel()
+
+	dbFile := t.TempDir() + "/oversized-index"
+	if err := os.WriteFile(dbFile, []byte(strings.Repeat("x", 64*1024+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewFileDBClient("test-ca", dbFile)
+	entries, err := client.Scan(context.Background())
+	if err == nil {
+		t.Fatal("Scan() error = nil, want scanner error")
+	}
+	if entries != nil {
+		t.Fatalf("Scan() entries = %#v, want nil", entries)
+	}
+	if !strings.Contains(err.Error(), "could not scan file DB") {
+		t.Fatalf("Scan() error = %q, want file DB context", err)
 	}
 }


### PR DESCRIPTION
## Summary

- return file scanner failures with the affected DB path
- reject an entire DynamoDB result set when any projected item is malformed
- include the malformed DynamoDB item index and attribute error in the returned error
- add regression tests for oversized file records and partial DynamoDB results

## Why

The file backend did not inspect `scanner.Err()`, so an I/O or token-size failure could publish a partial certificate-status set. The DynamoDB backend silently skipped malformed items, which could similarly hide certificate records without alerting operators.

## Impact

Database corruption and incomplete reads now fail the cache-generation scan instead of being treated as a successful partial snapshot. Existing valid records and schemas are unaffected.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2` (`0 issues`)
