### PR TITLE
Add graceful shutdown and drop container root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.26.5-alpine
 
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache gcompat \
+    && addgroup -S dyocsp \
+    && adduser -S -G dyocsp dyocsp
 
 ARG ARCH="amd64_v1"
 ARG OS="linux"
@@ -10,4 +12,5 @@ COPY LICENSE /LICENSE
 WORKDIR /dyocsp
 
 EXPOSE 80
+USER dyocsp
 ENTRYPOINT [ "/bin/dyocsp" ]

--- a/cache_batch.go
+++ b/cache_batch.go
@@ -304,28 +304,26 @@ func (c *CacheBatch) logBatchSummary(ctx context.Context, start time.Time) {
 		Msg("Cache generation batch completed.")
 }
 
-func (c *CacheBatch) waitForNextUpdate(ctx context.Context, waitDur time.Duration) {
+func (c *CacheBatch) waitForNextUpdate(ctx context.Context, waitDur time.Duration) bool {
 	logger := zerolog.Ctx(ctx)
 
 	logger.Info().Dur("wait", waitDur).
 		Time("next-update", c.nextUpdate).
 		Msg("Waiting for the next update.")
 
-	if c.quite != nil {
-	outer:
-		for {
-			select {
-			case <-time.After(waitDur):
-				break outer
-			case msg := <-c.quite:
-				// Stop when it received quite message
-				logger.Info().Msgf("Quite message received, stop loop: %s", msg)
-				c.quite <- "Loop stopped."
-				return
-			}
-		}
-	} else {
-		time.Sleep(waitDur)
+	timer := time.NewTimer(waitDur)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		logger.Info().Msg("Context canceled, stop loop.")
+		return false
+	case msg := <-c.quite:
+		logger.Info().Msgf("Quite message received, stop loop: %s", msg)
+		c.quite <- "Loop stopped."
+		return false
 	}
 }
 
@@ -343,6 +341,10 @@ func (c *CacheBatch) waitForNextUpdate(ctx context.Context, waitDur time.Duratio
 //   - Wait for next update.
 func (c *CacheBatch) Run(ctx context.Context) {
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		startTime := c.now()
 
 		logger := c.logger.With().Int("batch_serial", c.batchSerial).Logger()
@@ -360,7 +362,11 @@ func (c *CacheBatch) Run(ctx context.Context) {
 		logger.Info().Msg("Response cache updated.")
 
 		if c.updatedNotify != nil {
-			c.updatedNotify <- struct{}{}
+			select {
+			case c.updatedNotify <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 		}
 
 		// Summury of this loop batch
@@ -372,7 +378,9 @@ func (c *CacheBatch) Run(ctx context.Context) {
 		c.nextUpdate = c.nextUpdate.Add(c.interval)
 
 		// Wait for next update
-		c.waitForNextUpdate(ctx, waitDur)
+		if !c.waitForNextUpdate(ctx, waitDur) {
+			return
+		}
 
 		c.batchSerial++
 	}

--- a/cache_batch_test.go
+++ b/cache_batch_test.go
@@ -160,6 +160,42 @@ func TestNewCacheBatch_ErrDelayExceedsInterval(t *testing.T) {
 	}
 }
 
+func TestCacheBatchRunStopsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	client := StubCADBClient{"test-ca", []db.IntermidiateEntry{}}
+	store := cache.NewResponseCacheStore()
+	updated := make(chan struct{})
+	batch, err := NewCacheBatch(
+		"test-ca",
+		store,
+		client,
+		testCreateDelegatedResponder(t),
+		date.NowGMT(),
+		WithIntervalSec(60),
+		WithUpdatedNotifyChan(updated),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		batch.Run(ctx)
+	}()
+
+	<-updated
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not stop after context cancellation")
+	}
+}
+
 func TestCacheBatch_Run_DBNotChanged(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/dyocsp/main.go
+++ b/cmd/dyocsp/main.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	stdlog "log"
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -78,12 +81,12 @@ func newFileDBClient(cfg config.DyOCSPConfig) (db.FileDBClient, error) {
 	return db.NewFileDBClient(cfg.CA, cfg.FileDBFile), nil
 }
 
-func newDynamoDBClient(cfg config.DyOCSPConfig) (db.DynamoDBClient, error) {
+func newDynamoDBClient(ctx context.Context, cfg config.DyOCSPConfig) (db.DynamoDBClient, error) {
 	ca := cfg.CA
 	caTable := cfg.DynamoDBTableName
 	caGsi := cfg.DynamoDBCAGsi
 
-	aCfg, err := awsconfig.LoadDefaultConfig(context.TODO(),
+	aCfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(cfg.DynamoDBRegion),
 		awsconfig.WithRetryMaxAttempts(cfg.DynamoDBRetryMaxAttempts),
 	)
@@ -124,11 +127,12 @@ func chainHTTPAccessHandler(c alice.Chain) alice.Chain {
 	return chain
 }
 
-func run(cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
+const shutdownTimeout = 10 * time.Second
+
+func run(ctx context.Context, cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
 	setupLogger(cfg)
 
-	rootCtx := context.Background()
-	rootCtx, cancel := context.WithCancel(rootCtx)
+	rootCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Create DB client
@@ -139,7 +143,7 @@ func run(cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
 	case config.FileDBType:
 		dbClient, err = newFileDBClient(cfg)
 	case config.DynamoDBType:
-		dbClient, err = newDynamoDBClient(cfg)
+		dbClient, err = newDynamoDBClient(ctx, cfg)
 	default:
 		err = config.MissingParameterError{Param: "db.<db-type>"}
 	}
@@ -151,8 +155,6 @@ func run(cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
 	cacheStore := cache.NewResponseCacheStore()
 
 	// Create CacheBatch
-	quite := make(chan string)
-
 	blogger := log.Logger.With().Str("role", cacheBatchRole).Logger()
 	batch, err := dyocsp.NewCacheBatch(
 		cfg.CA,
@@ -165,14 +167,17 @@ func run(cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
 		dyocsp.WithDelay(time.Second*time.Duration(cfg.Delay)),
 		dyocsp.WithStrict(cfg.Strict),
 		dyocsp.WithLogger(&blogger),
-		dyocsp.WithQuiteChan(quite),
 	)
 	if err != nil {
 		return err
 	}
 
 	// Run batch generating caches
-	go batch.Run(rootCtx)
+	batchDone := make(chan struct{})
+	go func() {
+		defer close(batchDone)
+		batch.Run(rootCtx)
+	}()
 
 	// Create Server
 	hLogger := log.Logger.With().Str("role", CacheHandlerRole).Logger()
@@ -197,19 +202,31 @@ func run(cfg config.DyOCSPConfig, responder *dyocsp.Responder) error {
 		cacheHander,
 	)
 
-	// Run Server
-	err = server.ListenAndServe()
-	if err != nil {
-		if errors.Is(err, http.ErrServerClosed) {
-			panic(err)
-		}
-		cancel()
-		quite <- "Quite on error"
-		stdlog.Printf("Batch loop quited: received message from caching batch: %s", <-quite)
-		stdlog.Fatalf("error:listening server: %v", err)
-	}
+	serverError := make(chan error, 1)
+	go func() {
+		serverError <- server.ListenAndServe()
+	}()
 
-	return nil
+	select {
+	case err = <-serverError:
+		cancel()
+		<-batchDone
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return fmt.Errorf("listening server: %w", err)
+	case <-ctx.Done():
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+		defer shutdownCancel()
+
+		shutdownErr := server.Shutdown(shutdownCtx)
+		cancel()
+		<-batchDone
+		if shutdownErr != nil {
+			return fmt.Errorf("shutting down server: %w", shutdownErr)
+		}
+		return nil
+	}
 }
 
 func main() {
@@ -257,7 +274,10 @@ func main() {
 
 	responder := newResponder(cfg)
 
-	err = run(cfg, responder)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err = run(ctx, cfg, responder)
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/cmd/dyocsp/main_test.go
+++ b/cmd/dyocsp/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"io"
@@ -85,7 +86,22 @@ func TestMain_InternalIntegration(t *testing.T) {
 
 	// Run Responder Batch & Server
 	responder := newResponder(cfg)
-	go run(cfg, responder)
+	ctx, cancel := context.WithCancel(context.Background())
+	runError := make(chan error, 1)
+	go func() {
+		runError <- run(ctx, cfg, responder)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-runError:
+			if err != nil {
+				t.Errorf("run() error = %v", err)
+			}
+		case <-time.After(shutdownTimeout + time.Second):
+			t.Error("run() did not stop after context cancellation")
+		}
+	}()
 
 	endpoint := "http://localhost:9080"
 	tryN := 20


### PR DESCRIPTION
## Summary

- stop the cache batch promptly when its context is canceled
- handle SIGINT and SIGTERM with `http.Server.Shutdown`
- wait for in-flight HTTP requests and the cache goroutine before returning
- propagate server startup and shutdown errors instead of panicking or calling fatal from `run`
- pass lifecycle context into AWS configuration loading
- run the distributed container as a dedicated non-root user
- add cancellation coverage for the cache loop and clean up the internal integration server

## Why

The process had no signal-driven graceful shutdown path. `http.ErrServerClosed` caused a panic, the cache loop relied on a bidirectional control channel, and tests left server and batch goroutines running. The container also handled private signing keys while running as root.

## Impact

Deployments can terminate without abruptly dropping active OCSP requests, and background work exits deterministically. The container no longer runs the responder as root. Valid startup and request behavior remain unchanged.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2` (`0 issues`)
