### PR TITLE
Query DynamoDB CA index efficiently

### DIFF
--- a/docs/dynamodb.md
+++ b/docs/dynamodb.md
@@ -17,7 +17,9 @@ This key is not used in DyOCSP, but it is useful for managing revocation informa
 | ----------- | ----------- | ----------- |
 |ca|S|HASH|
 
-DyOCSP uses this global secondary index for utilizing the [Scan API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html).
+DyOCSP uses this global secondary index with the
+[Query API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html)
+to retrieve only the configured CA partition.
 
 #### Required Attributes for An Items
 |AttributeName|AttributeType|Description|
@@ -53,9 +55,9 @@ The following IAM policy will suffice for DyOCSP:
         {
             "Effect": "Allow",
             "Action": [
-                "dynamodb:Scan"
+                "dynamodb:Query"
             ],
-            "Resource": "arn:aws:dynamodb:your-region:your-aws-id:table/ca_db"
+            "Resource": "arn:aws:dynamodb:your-region:your-aws-id:table/ca_db/index/ca-index"
         }
     ]
 }

--- a/pkg/db/ca_db_client.go
+++ b/pkg/db/ca_db_client.go
@@ -1,5 +1,10 @@
 package db
 
+const (
+	serialAttribute  = "serial"
+	revTypeAttribute = "rev_type"
+)
+
 // IntermediateEntry is a struct that holds raw data scanned from the database
 // without any modifications. This structure handles variations in data originating
 // from diverse background databases.

--- a/pkg/db/dynamodb_client.go
+++ b/pkg/db/dynamodb_client.go
@@ -10,14 +10,22 @@ import (
 )
 
 // The DynamoDBClient is an implementation of the CADBClient interface. It is used
-// to scan the certificate revocation status from the DynamoDB. Please refer to the
+// to query the certificate revocation status from DynamoDB. Please refer to the
 // documentation for specifications on the table and index.
 type DynamoDBClient struct {
-	client    *dynamodb.Client
+	client    dynamoDBQueryAPI
 	caName    *string
 	tableName *string
 	indexName *string
 	timeout   int
+}
+
+type dynamoDBQueryAPI interface {
+	Query(
+		ctx context.Context,
+		input *dynamodb.QueryInput,
+		optFns ...func(*dynamodb.Options),
+	) (*dynamodb.QueryOutput, error)
 }
 
 // NewDynamoDBClient creates and returns new DynamoDBClient instance.
@@ -73,12 +81,12 @@ func UnmarshalDynamoDBItem(item map[string]types.AttributeValue) (IntermidiateEn
 		return IntermidiateEntry{}, err
 	}
 
-	serial, err := unmarshalItem(item, "serial")
+	serial, err := unmarshalItem(item, serialAttribute)
 	if err != nil {
 		return IntermidiateEntry{}, err
 	}
 
-	revType, err := unmarshalItem(item, "rev_type")
+	revType, err := unmarshalItem(item, revTypeAttribute)
 	if err != nil {
 		return IntermidiateEntry{}, err
 	}
@@ -108,13 +116,13 @@ func UnmarshalDynamoDBItem(item map[string]types.AttributeValue) (IntermidiateEn
 	}, nil
 }
 
-// Scan read sthe items from the table.
-// Set the filter expression to the secondary global index with the "ca" hash key.
+// Scan reads the items for a CA from the configured global secondary index.
+// Set the key condition expression using the "ca" partition key.
 // Retrieve the items and unmarshal them into IntermediateEntry.
 func (d DynamoDBClient) Scan(ctx context.Context) ([]IntermidiateEntry, error) {
-	var input dynamodb.ScanInput
+	var input dynamodb.QueryInput
 
-	fex := "ca = :ca"
+	keyCondition := "ca = :ca"
 	pje := "ca,serial,rev_type,exp_date,rev_date,crl_reason"
 	eav, err := attributevalue.MarshalMap(map[string]string{":ca": *d.caName})
 	if err != nil {
@@ -124,7 +132,7 @@ func (d DynamoDBClient) Scan(ctx context.Context) ([]IntermidiateEntry, error) {
 	input.TableName = d.tableName
 	input.IndexName = d.indexName
 	input.Select = "SPECIFIC_ATTRIBUTES"
-	input.FilterExpression = &fex
+	input.KeyConditionExpression = &keyCondition
 	input.ExpressionAttributeValues = eav
 	input.ProjectionExpression = &pje
 
@@ -136,7 +144,7 @@ func (d DynamoDBClient) Scan(ctx context.Context) ([]IntermidiateEntry, error) {
 	for {
 		input.ExclusiveStartKey = lastEvaluatedKey
 
-		out, err := d.client.Scan(ctx, &input)
+		out, err := d.client.Query(ctx, &input)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/db/dynamodb_client_query_test.go
+++ b/pkg/db/dynamodb_client_query_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type queryStub struct {
+	inputs []*dynamodb.QueryInput
+}
+
+func (s *queryStub) Query(
+	_ context.Context,
+	input *dynamodb.QueryInput,
+	_ ...func(*dynamodb.Options),
+) (*dynamodb.QueryOutput, error) {
+	s.inputs = append(s.inputs, input)
+	if len(s.inputs) == 1 {
+		return &dynamodb.QueryOutput{
+			Items:            []map[string]types.AttributeValue{validDynamoDBItem()},
+			LastEvaluatedKey: map[string]types.AttributeValue{"serial": &types.AttributeValueMemberS{Value: "1234"}},
+		}, nil
+	}
+	return &dynamodb.QueryOutput{}, nil
+}
+
+func validDynamoDBItem() map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"ca":             &types.AttributeValueMemberS{Value: "test-ca"},
+		serialAttribute:  &types.AttributeValueMemberS{Value: "1234"},
+		revTypeAttribute: &types.AttributeValueMemberS{Value: "V"},
+		"exp_date":       &types.AttributeValueMemberS{Value: "300101000000Z"},
+		"rev_date":       &types.AttributeValueMemberS{Value: ""},
+		"crl_reason":     &types.AttributeValueMemberS{Value: ""},
+	}
+}
+
+func TestDynamoDBClientScanQueriesConfiguredIndex(t *testing.T) {
+	t.Parallel()
+
+	client := &queryStub{}
+	caName := "test-ca"
+	tableName := "ca-db"
+	indexName := "ca-index"
+	dbClient := DynamoDBClient{
+		client:    client,
+		caName:    &caName,
+		tableName: &tableName,
+		indexName: &indexName,
+		timeout:   1,
+	}
+
+	entries, err := dbClient.Scan(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Scan() returned %d entries, want 1", len(entries))
+	}
+	if len(client.inputs) != 2 {
+		t.Fatalf("Query() called %d times, want 2", len(client.inputs))
+	}
+
+	firstInput := client.inputs[0]
+	if firstInput.KeyConditionExpression == nil || *firstInput.KeyConditionExpression != "ca = :ca" {
+		t.Fatalf("KeyConditionExpression = %v, want ca partition condition", firstInput.KeyConditionExpression)
+	}
+	if firstInput.FilterExpression != nil {
+		t.Fatalf("FilterExpression = %v, want nil", firstInput.FilterExpression)
+	}
+	if firstInput.IndexName == nil || *firstInput.IndexName != indexName {
+		t.Fatalf("IndexName = %v, want %q", firstInput.IndexName, indexName)
+	}
+	if !reflect.DeepEqual(client.inputs[1].ExclusiveStartKey, map[string]types.AttributeValue{
+		"serial": &types.AttributeValueMemberS{Value: "1234"},
+	}) {
+		t.Fatalf("second Query() ExclusiveStartKey = %#v", client.inputs[1].ExclusiveStartKey)
+	}
+}

--- a/pkg/db/entry_exchange.go
+++ b/pkg/db/entry_exchange.go
@@ -43,7 +43,7 @@ func (e *EntryExchange) VerifySerial(target string) (*big.Int, error) {
 	// RFC rfc5280 4.1.2.2. Serial Number.
 	if len(target) > SerialMaxOctetLength*2 {
 		return nil, InvalidEntryError{
-			attr: "serial",
+			attr: serialAttribute,
 			msg:  target,
 		}
 	}
@@ -69,13 +69,13 @@ func (e *EntryExchange) VerifyRevType(
 	if target == string(Valid) {
 		if revDate != "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but rev_date exists", Valid),
 			}
 		}
 		if crlReason != "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but crl_reason exists", Valid),
 			}
 		}
@@ -85,7 +85,7 @@ func (e *EntryExchange) VerifyRevType(
 	if target == string(Revoked) {
 		if revDate == "" {
 			return "", InvalidEntryError{
-				attr: "rev_type",
+				attr: revTypeAttribute,
 				msg:  fmt.Sprintf("rev_status is %s but rev_date does not exist", Revoked),
 			}
 		}
@@ -93,7 +93,7 @@ func (e *EntryExchange) VerifyRevType(
 	}
 
 	return "", InvalidEntryError{
-		attr: "rev_type",
+		attr: revTypeAttribute,
 		msg:  target,
 	}
 }


### PR DESCRIPTION
## Summary

- replace DynamoDB `Scan` plus a filter expression with a partition-key `Query` against the configured CA index
- preserve pagination through `LastEvaluatedKey`
- introduce a narrow query interface and unit-test the generated key condition, index, and pagination
- update the DynamoDB documentation and least-privilege IAM example

## Why

A filtered `Scan` reads the full index before discarding records belonging to other CAs. Its latency and read-capacity cost therefore grow with the whole table rather than the configured CA partition.

## Impact

DynamoDB work is proportional to records for the selected CA. Deployments must allow `dynamodb:Query` on the configured index instead of `dynamodb:Scan`; the documentation includes the required resource ARN.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2` (`0 issues`)
